### PR TITLE
A few tweaks

### DIFF
--- a/TesteSQLite3.xcodeproj/project.pbxproj
+++ b/TesteSQLite3.xcodeproj/project.pbxproj
@@ -307,9 +307,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 44KKSVCA9L;
+				DEVELOPMENT_TEAM = UZAPXQTVQ4;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TesteSQLite3/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -331,9 +332,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 44KKSVCA9L;
+				DEVELOPMENT_TEAM = UZAPXQTVQ4;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TesteSQLite3/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/TesteSQLite3/SceneDelegate.m
+++ b/TesteSQLite3/SceneDelegate.m
@@ -14,13 +14,11 @@
 
 @implementation SceneDelegate
 
-
 - (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
     // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
     // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
     // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
 }
-
 
 - (void)sceneDidDisconnect:(UIScene *)scene {
     // Called as the scene is being released by the system.
@@ -29,30 +27,25 @@
     // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
 }
 
-
 - (void)sceneDidBecomeActive:(UIScene *)scene {
     // Called when the scene has moved from an inactive state to an active state.
     // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
 }
-
 
 - (void)sceneWillResignActive:(UIScene *)scene {
     // Called when the scene will move from an active state to an inactive state.
     // This may occur due to temporary interruptions (ex. an incoming phone call).
 }
 
-
 - (void)sceneWillEnterForeground:(UIScene *)scene {
     // Called as the scene transitions from the background to the foreground.
     // Use this method to undo the changes made on entering the background.
 }
-
 
 - (void)sceneDidEnterBackground:(UIScene *)scene {
     // Called as the scene transitions from the foreground to the background.
     // Use this method to save data, release shared resources, and store enough scene-specific state information
     // to restore the scene back to its current state.
 }
-
 
 @end

--- a/TesteSQLite3/ViewController.m
+++ b/TesteSQLite3/ViewController.m
@@ -12,7 +12,6 @@
 static NSString* systemSqliteDBFileName = @"testdb.sqlite";
 
 @interface ViewController ()
-
 @property(nonatomic, strong)NSString* dbFilePath;
 @end
 
@@ -25,34 +24,29 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
     self.dbFilePath = [documentsDir.path stringByAppendingPathComponent:systemSqliteDBFileName];
     // Do any additional setup after loading the view.
     NSArray *array = [[NSArray alloc] initWithArray: [self columnMethodsTest]];
-    NSLog(@"aqui");
+    for (NSString *string in array) {
+        NSLog(@"%@", string);
+    }
 }
 
--(BOOL)dbExists
-{
+- (BOOL)dbExists  {
     return [[NSFileManager defaultManager] fileExistsAtPath:self.dbFilePath];
 }
 
--(BOOL)createDB
-{
-    if ([self dbExists])
-    {
+- (BOOL)createDB {
+    if ([self dbExists]) {
         return YES;
     }
     
     sqlite3* dbConnection;
-    if (SQLITE_OK == sqlite3_open([self.dbFilePath UTF8String], &dbConnection))
-    {
-    
+    if (SQLITE_OK == sqlite3_open([self.dbFilePath UTF8String], &dbConnection)) {
         char* errorMsg = NULL;
         const char* sqlCreateStatement = "create table if not exists \
         empInfo (id integer primary key, firstname text, lastname text, address text);";
         
-        if (SQLITE_OK != sqlite3_exec(dbConnection, sqlCreateStatement, NULL, NULL, &errorMsg))
-        {
+        if (SQLITE_OK != sqlite3_exec(dbConnection, sqlCreateStatement, NULL, NULL, &errorMsg)) {
             NSString* errorMsgFromExec = nil;
-            if (NULL != errorMsg)
-            {
+            if (errorMsg) {
                 errorMsgFromExec = [NSString stringWithCString:errorMsg encoding:NSASCIIStringEncoding];
                 sqlite3_free(errorMsg);
             }
@@ -70,73 +64,73 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
     return NO;
 }
 
--(NSArray*)columnMethodsTest
-{
+- (NSArray*)columnMethodsTest {
     NSMutableArray *columnInfo = [[NSMutableArray alloc] init];
 
-    if (![self createDB])
-    {
+    if (![self createDB]) {
         NSLog(@"Error - failed to create/open a database.");
         return columnInfo;
     }
 
     sqlite3* dbConnection;
-    if (SQLITE_OK == sqlite3_open([self.dbFilePath UTF8String], &dbConnection))
-    {
-        const char* sqlSelectStatement = "select * from empInfo";
-        sqlite3_stmt *statement;
-        if (SQLITE_OK == sqlite3_prepare_v2(dbConnection, sqlSelectStatement, -1, &statement, NULL))
-        {
-            //extract column information
-            [columnInfo addObject:[NSString stringWithFormat:@"\nSqlite3 Version: %@.",[[NSString alloc] initWithUTF8String:(char*)sqlite3_libversion()]]];
-
-            int cols = sqlite3_column_count(statement);
-
-            [columnInfo addObject:[NSString stringWithFormat:@"\nColumn Count is %d.", cols]];
-            for (int i=0; i<cols; i++)
-            {
-                const char *string = sqlite3_column_name(statement, i);
-                NSString* columnName = string ? @(string) : @"";
-                NSLog(@"sqlite3_column_name: %@", columnName);
-
-                /* For sqlite3column, if static lib test, the method can return NULL.
-                ** NULL is returned if the result column is an expression or constant or
-                ** anything else which is not an unambiguous reference to a database column.
-                */
-
-                string = sqlite3_column_database_name(statement, i);
-                NSString* columnDBName = string ? @(string) : @"";
-                NSLog(@"sqlite3_column_database_name: %@", columnDBName);
-
-                string = sqlite3_column_table_name(statement, i);
-                NSString* columnTableName = string ? @(string) : @"";
-                NSLog(@"sqlite3_column_table_name: %@", columnTableName);
-
-                string = sqlite3_column_origin_name(statement, i);
-                NSString* columnOriginName = string ? @(string) : @"";
-                NSLog(@"sqlite3_column_origin_name: %@", columnOriginName);
-                
-                NSMutableString *entry = [NSMutableString stringWithFormat:@"\nColumn #%d:", i];
-                [entry appendString:[NSString stringWithFormat:@"\nName:\t          %@", columnName]];
-                [entry appendString:[NSString stringWithFormat:@"\nDatabase Name:\t %@", columnDBName]];
-                [entry appendString:[NSString stringWithFormat:@"\nTable Name:\t    %@", columnTableName]];
-                [entry appendString:[NSString stringWithFormat:@"\nOrigin Name:\t   %@", columnOriginName]];
-                [columnInfo addObject:entry];
-            }
-            sqlite3_finalize(statement);
-        }
+    if (SQLITE_OK != sqlite3_open([self.dbFilePath UTF8String], &dbConnection)) {
+        // Fail to open the database.
+        NSLog(@"Error - failed to open the database. %s", sqlite3_errmsg(dbConnection) ?: "Unknown error");
 
         sqlite3_close(dbConnection);
         return columnInfo;
     }
 
+    const char* sqlSelectStatement = "select * from empInfo";
+    sqlite3_stmt *statement;
+    if (SQLITE_OK != sqlite3_prepare_v2(dbConnection, sqlSelectStatement, -1, &statement, NULL)) {
+        NSLog(@"Error - failed to prepare select statement. %s", sqlite3_errmsg(dbConnection) ?: "Unknown error");
+
+        sqlite3_close(dbConnection);
+        return columnInfo;
+    }
+
+    //extract column information
+    [columnInfo addObject:[NSString stringWithFormat:@"\nSqlite3 Version: %@.",[[NSString alloc] initWithUTF8String:(char*)sqlite3_libversion()]]];
+
+    int cols = sqlite3_column_count(statement);
+
+    [columnInfo addObject:[NSString stringWithFormat:@"\nColumn Count is %d.", cols]];
+    for (int i=0; i<cols; i++) {
+        const char *string = sqlite3_column_name(statement, i);
+        NSString* columnName = @(string ?: "");
+        NSLog(@"sqlite3_column_name: %@", columnName);
+
+        /* For sqlite3column, if static lib test, the method can return NULL.
+         ** NULL is returned if the result column is an expression or constant or
+         ** anything else which is not an unambiguous reference to a database column.
+         */
+
+        string = sqlite3_column_database_name(statement, i);
+        NSString* columnDBName = @(string ?: "");
+        NSLog(@"sqlite3_column_database_name: %@", columnDBName);
+
+        string = sqlite3_column_table_name(statement, i);
+        NSString* columnTableName = @(string ?: "");
+        NSLog(@"sqlite3_column_table_name: %@", columnTableName);
+
+        string = sqlite3_column_origin_name(statement, i);
+        NSString* columnOriginName = @(string ?: "");
+        NSLog(@"sqlite3_column_origin_name: %@", columnOriginName);
+
+        NSMutableString *entry = [NSMutableString stringWithFormat:@"\nColumn #%d:", i];
+        [entry appendString:[NSString stringWithFormat:@"\nName:\t          %@", columnName]];
+        [entry appendString:[NSString stringWithFormat:@"\nDatabase Name:\t %@", columnDBName]];
+        [entry appendString:[NSString stringWithFormat:@"\nTable Name:\t    %@", columnTableName]];
+        [entry appendString:[NSString stringWithFormat:@"\nOrigin Name:\t   %@", columnOriginName]];
+        [columnInfo addObject:entry];
+
+        NSLog(@"");
+    }
+    sqlite3_finalize(statement);
     sqlite3_close(dbConnection);
 
-    // Fail to open the database.
-    NSLog(@"Error - failed to open the database.");
     return columnInfo;
 }
-
-
 
 @end

--- a/TesteSQLite3/ViewController.m
+++ b/TesteSQLite3/ViewController.m
@@ -95,20 +95,26 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
             [columnInfo addObject:[NSString stringWithFormat:@"\nColumn Count is %d.", cols]];
             for (int i=0; i<cols; i++)
             {
-                NSString* columnName = ((sqlite3_column_name(statement, i)) != NULL) ? [[NSString alloc] initWithUTF8String: (char*)sqlite3_column_name(statement, i)] : @"";
-//                NSLog(@"%@", columnName);
-                /* For sqlite3colum, if static lib test, the method can return NULL.
+                const char *string = sqlite3_column_name(statement, i);
+                NSString* columnName = string ? @(string) : @"";
+                NSLog(@"sqlite3_column_name: %@", columnName);
+
+                /* For sqlite3column, if static lib test, the method can return NULL.
                 ** NULL is returned if the result column is an expression or constant or
                 ** anything else which is not an unambiguous reference to a database column.
                 */
-                
-                NSLog(@"%s", sqlite3_column_database_name(statement, i));
-                NSString* columnDBName = ((sqlite3_column_database_name(statement, i)) != NULL) ? [[NSString alloc] initWithUTF8String: (char*)sqlite3_column_database_name(statement, i)] : @"";
-                NSLog(@"%@",columnDBName);
-                NSString* columnTableName = ((sqlite3_column_table_name(statement, i)) != NULL) ? [[NSString alloc] initWithUTF8String: (char*)sqlite3_column_table_name(statement, i)] : @"";
-                NSLog(@"%@",columnTableName);
-                NSString* columnOriginName = ((sqlite3_column_origin_name(statement, i)) != NULL) ? [[NSString alloc] initWithUTF8String: (char*)sqlite3_column_origin_name(statement, i)] : @"";
-                NSLog(@"%@",columnOriginName);
+
+                string = sqlite3_column_database_name(statement, i);
+                NSString* columnDBName = string ? @(string) : @"";
+                NSLog(@"sqlite3_column_database_name: %@", columnDBName);
+
+                string = sqlite3_column_table_name(statement, i);
+                NSString* columnTableName = string ? @(string) : @"";
+                NSLog(@"sqlite3_column_table_name: %@", columnTableName);
+
+                string = sqlite3_column_origin_name(statement, i);
+                NSString* columnOriginName = string ? @(string) : @"";
+                NSLog(@"sqlite3_column_origin_name: %@", columnOriginName);
                 
                 NSMutableString *entry = [NSMutableString stringWithFormat:@"\nColumn #%d:", i];
                 [entry appendString:[NSString stringWithFormat:@"\nName:\t          %@", columnName]];

--- a/TesteSQLite3/ViewController.m
+++ b/TesteSQLite3/ViewController.m
@@ -66,6 +66,7 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
         return YES;
     }
     
+    sqlite3_close(dbConnection); // you need to close this even if open failed
     return NO;
 }
 
@@ -122,6 +123,8 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
         sqlite3_close(dbConnection);
         return columnInfo;
     }
+
+    sqlite3_close(dbConnection);
 
     // Fail to open the database.
     NSLog(@"Error - failed to open the database.");


### PR DESCRIPTION
I’ve added two missing `sqlite3_close` calls, and have eliminated redundant `sqlite3_column_xxx` calls.

All of that having been said, this ran on my iOS 13 device without crashing.