### PR TITLE
Update SQLCipher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,68 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+
+Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,10 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'TesteSQLite3' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for TesteSQLite3
+  pod 'SQLCipher'
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,20 @@
+PODS:
+  - SQLCipher (4.4.0):
+    - SQLCipher/standard (= 4.4.0)
+  - SQLCipher/common (4.4.0)
+  - SQLCipher/standard (4.4.0):
+    - SQLCipher/common
+
+DEPENDENCIES:
+  - SQLCipher
+
+SPEC REPOS:
+  trunk:
+    - SQLCipher
+
+SPEC CHECKSUMS:
+  SQLCipher: e434ed542b24f38ea7b36468a13f9765e1b5c072
+
+PODFILE CHECKSUM: 60be94dc273be86bdb99be49bb1585827bcf2f30
+
+COCOAPODS: 1.9.1

--- a/TesteSQLite3.xcodeproj/project.pbxproj
+++ b/TesteSQLite3.xcodeproj/project.pbxproj
@@ -14,28 +14,9 @@
 		973A6E1A248027E800EA2393 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 973A6E19248027E800EA2393 /* Assets.xcassets */; };
 		973A6E1D248027E800EA2393 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 973A6E1B248027E800EA2393 /* LaunchScreen.storyboard */; };
 		973A6E20248027E800EA2393 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 973A6E1F248027E800EA2393 /* main.m */; };
-		973A6E3324805AED00EA2393 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 973A6E272480283700EA2393 /* libsqlite3.tbd */; };
-		979A8A2424868FC60003FF0C /* libsqlcipher.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 97200D0824857702000F06E3 /* libsqlcipher.dylib */; };
-		979A8A2524868FC60003FF0C /* libsqlcipher.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 97200D0824857702000F06E3 /* libsqlcipher.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		979A8A2624868FC60003FF0C /* Embed Libraries */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				979A8A2524868FC60003FF0C /* libsqlcipher.dylib in Embed Libraries */,
-			);
-			name = "Embed Libraries";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
-		97200D0424857694000F06E3 /* libsqlcipher.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlcipher.dylib; path = ../../Bluecedar02/prometheus/mapnext/apps/ios/PrometheusTestApp/PrometheusTestApp/DatabaseTests/libsqlcipher.dylib; sourceTree = "<group>"; };
-		97200D0824857702000F06E3 /* libsqlcipher.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlcipher.dylib; path = TesteSQLite3/libsqlcipher.dylib; sourceTree = "<group>"; };
 		973A6E0A248027E600EA2393 /* TesteSQLite3.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TesteSQLite3.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		973A6E0D248027E600EA2393 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		973A6E0E248027E600EA2393 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -48,7 +29,6 @@
 		973A6E1C248027E800EA2393 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		973A6E1E248027E800EA2393 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		973A6E1F248027E800EA2393 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		973A6E272480283700EA2393 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,8 +36,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				979A8A2424868FC60003FF0C /* libsqlcipher.dylib in Frameworks */,
-				973A6E3324805AED00EA2393 /* libsqlite3.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,9 +80,6 @@
 		973A6E262480283700EA2393 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				97200D0424857694000F06E3 /* libsqlcipher.dylib */,
-				97200D0824857702000F06E3 /* libsqlcipher.dylib */,
-				973A6E272480283700EA2393 /* libsqlite3.tbd */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -119,7 +94,6 @@
 				973A6E06248027E600EA2393 /* Sources */,
 				973A6E07248027E600EA2393 /* Frameworks */,
 				973A6E08248027E600EA2393 /* Resources */,
-				979A8A2624868FC60003FF0C /* Embed Libraries */,
 			);
 			buildRules = (
 			);

--- a/TesteSQLite3.xcodeproj/project.pbxproj
+++ b/TesteSQLite3.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		564213E0B36E0FED5BF5689E /* Pods_TesteSQLite3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F6F3DCE97D9E94714FE3577 /* Pods_TesteSQLite3.framework */; };
 		973A6E0F248027E600EA2393 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 973A6E0E248027E600EA2393 /* AppDelegate.m */; };
 		973A6E12248027E600EA2393 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 973A6E11248027E600EA2393 /* SceneDelegate.m */; };
 		973A6E15248027E600EA2393 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 973A6E14248027E600EA2393 /* ViewController.m */; };
@@ -17,6 +18,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7F6F3DCE97D9E94714FE3577 /* Pods_TesteSQLite3.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TesteSQLite3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		973A6E0A248027E600EA2393 /* TesteSQLite3.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TesteSQLite3.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		973A6E0D248027E600EA2393 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		973A6E0E248027E600EA2393 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -29,6 +31,8 @@
 		973A6E1C248027E800EA2393 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		973A6E1E248027E800EA2393 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		973A6E1F248027E800EA2393 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		AE6E2B4B5D16EAC0D7D8275E /* Pods-TesteSQLite3.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TesteSQLite3.debug.xcconfig"; path = "Target Support Files/Pods-TesteSQLite3/Pods-TesteSQLite3.debug.xcconfig"; sourceTree = "<group>"; };
+		D7500A894243D9C5A745378E /* Pods-TesteSQLite3.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TesteSQLite3.release.xcconfig"; path = "Target Support Files/Pods-TesteSQLite3/Pods-TesteSQLite3.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -36,6 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				564213E0B36E0FED5BF5689E /* Pods_TesteSQLite3.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -48,6 +53,7 @@
 				973A6E0C248027E600EA2393 /* TesteSQLite3 */,
 				973A6E0B248027E600EA2393 /* Products */,
 				973A6E262480283700EA2393 /* Frameworks */,
+				D026A0A88E7EBE3F5FE3A756 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -80,8 +86,19 @@
 		973A6E262480283700EA2393 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7F6F3DCE97D9E94714FE3577 /* Pods_TesteSQLite3.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D026A0A88E7EBE3F5FE3A756 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				AE6E2B4B5D16EAC0D7D8275E /* Pods-TesteSQLite3.debug.xcconfig */,
+				D7500A894243D9C5A745378E /* Pods-TesteSQLite3.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -91,9 +108,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 973A6E23248027E800EA2393 /* Build configuration list for PBXNativeTarget "TesteSQLite3" */;
 			buildPhases = (
+				2EB36501F2607F627DBA962B /* [CP] Check Pods Manifest.lock */,
 				973A6E06248027E600EA2393 /* Sources */,
 				973A6E07248027E600EA2393 /* Frameworks */,
 				973A6E08248027E600EA2393 /* Resources */,
+				E798F6C16B0CC24361B72497 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -148,6 +167,48 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2EB36501F2607F627DBA962B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TesteSQLite3-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E798F6C16B0CC24361B72497 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TesteSQLite3/Pods-TesteSQLite3-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TesteSQLite3/Pods-TesteSQLite3-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TesteSQLite3/Pods-TesteSQLite3-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		973A6E06248027E600EA2393 /* Sources */ = {
@@ -295,6 +356,7 @@
 		};
 		973A6E24248027E800EA2393 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AE6E2B4B5D16EAC0D7D8275E /* Pods-TesteSQLite3.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -320,6 +382,7 @@
 		};
 		973A6E25248027E800EA2393 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D7500A894243D9C5A745378E /* Pods-TesteSQLite3.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";

--- a/TesteSQLite3.xcworkspace/contents.xcworkspacedata
+++ b/TesteSQLite3.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:TesteSQLite3.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/TesteSQLite3.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TesteSQLite3.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/TesteSQLite3/ViewController.m
+++ b/TesteSQLite3/ViewController.m
@@ -20,8 +20,16 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
 - (void)viewDidLoad {
     [super viewDidLoad];
     NSURL* documentsDir = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
-           
+
     self.dbFilePath = [documentsDir.path stringByAppendingPathComponent:systemSqliteDBFileName];
+
+    if (![self createDB]) {
+        NSLog(@"Error - failed to create/open a database.");
+        return;
+    }
+
+    [self testSqlCipher];
+
     // Do any additional setup after loading the view.
     NSArray *array = [[NSArray alloc] initWithArray: [self columnMethodsTest]];
     for (NSString *string in array) {
@@ -37,9 +45,10 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
     if ([self dbExists]) {
         return YES;
     }
-    
+
     sqlite3* dbConnection;
-    if (SQLITE_OK == sqlite3_open([self.dbFilePath UTF8String], &dbConnection)) {
+
+    if ((dbConnection = [self openDatabase])) {
         char* errorMsg = NULL;
         const char* sqlCreateStatement = "create table if not exists \
         empInfo (id integer primary key, firstname text, lastname text, address text);";
@@ -54,30 +63,21 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
             NSLog(@"Error executing sqlite3 query:\"%@\" - error message:%@",
                   [NSString stringWithCString:sqlCreateStatement encoding:NSASCIIStringEncoding],
                   errorMsgFromExec);
+            sqlite3_close(dbConnection);
             return NO;
         }
         sqlite3_close(dbConnection);
         return YES;
     }
     
-    sqlite3_close(dbConnection); // you need to close this even if open failed
     return NO;
 }
 
 - (NSArray*)columnMethodsTest {
     NSMutableArray *columnInfo = [[NSMutableArray alloc] init];
 
-    if (![self createDB]) {
-        NSLog(@"Error - failed to create/open a database.");
-        return columnInfo;
-    }
-
     sqlite3* dbConnection;
-    if (SQLITE_OK != sqlite3_open([self.dbFilePath UTF8String], &dbConnection)) {
-        // Fail to open the database.
-        NSLog(@"Error - failed to open the database. %s", sqlite3_errmsg(dbConnection) ?: "Unknown error");
-
-        sqlite3_close(dbConnection);
+    if (!(dbConnection = [self openDatabase])) {
         return columnInfo;
     }
 
@@ -131,6 +131,69 @@ static NSString* systemSqliteDBFileName = @"testdb.sqlite";
     sqlite3_close(dbConnection);
 
     return columnInfo;
+}
+
+- (BOOL)setKeyForDatabase:(sqlite3 *)db {
+    int rc;
+    const char* key = [@"BIGSecret" UTF8String];
+    if ((rc = sqlite3_key(db, key, (int)strlen(key))) != SQLITE_OK) {
+        NSLog(@"sqlite3_key error: %d %s", rc, sqlite3_errmsg(db));
+    }
+    return rc == SQLITE_OK;
+}
+
+- (sqlite3 *)openDatabase {
+    sqlite3 *db;
+    int rc;
+
+    if ((rc = sqlite3_open([self.dbFilePath UTF8String], &db)) != SQLITE_OK) {
+        NSLog(@"sqlite3_open error: %d %s", rc, sqlite3_errmsg(db));
+        sqlite3_close(db);
+        return NULL;
+    }
+
+    if (![self setKeyForDatabase:db]) {
+        sqlite3_close(db);
+        return NULL;
+    }
+
+    return db;
+}
+
+- (void)testSqlCipher {
+    sqlite3 *db;
+    sqlite3_stmt *stmt;
+    int rc;
+    bool sqlcipher_valid = NO;
+
+    if (!(db = [self openDatabase])) {
+        return;
+    }
+
+    if ((rc = sqlite3_exec(db, (const char*) "SELECT count(*) FROM sqlite_master;", NULL, NULL, NULL)) != SQLITE_OK) {
+        NSLog(@"sqlite3_exec error: %d %s", rc, sqlite3_errmsg(db));
+    }
+
+    if ((rc = sqlite3_prepare_v2(db, "PRAGMA cipher_version;", -1, &stmt, NULL)) != SQLITE_OK) {
+        NSLog(@"sqlite3_prepare_v2 error: %d %s", rc, sqlite3_errmsg(db));
+        sqlite3_close(db);
+        return;
+    }
+
+    if ((rc = sqlite3_step(stmt) != SQLITE_ROW)) {
+        NSLog(@"sqlite3_step error: %d %s", rc, sqlite3_errmsg(db));
+    }
+
+    const unsigned char *ver = sqlite3_column_text(stmt, 0);
+    if (ver != NULL) {
+        sqlcipher_valid = YES;
+        NSLog(@"cipher_version = %s", ver);
+        // password is correct (or database initialize), and verified to be using sqlcipher
+    }
+
+    sqlite3_finalize(stmt);
+
+    sqlite3_close(db);
 }
 
 @end


### PR DESCRIPTION
I removed old SQLCipher file and re-added it via Cocoapods and the crash went away. You must have been using an outdated SQLCipher implementation.

You can update SQLCipher however you want. I’ve done it via Cocoapods here. So, note that you’ll need to open `.xcworkspace` not `.xcodeproj`.

Also note that if you already have unencrypted db in Documents path, you might get cryptic "26 - file is not a database" message. You’ll need to key it. Probably easiest to just remove the db and then run the app (which will recreate it, with key).